### PR TITLE
External permission fix android

### DIFF
--- a/android/src/main/java/com/imagepicker/permissions/PermissionUtils.java
+++ b/android/src/main/java/com/imagepicker/permissions/PermissionUtils.java
@@ -2,6 +2,8 @@ package com.imagepicker.permissions;
 
 import android.app.Activity;
 import android.content.DialogInterface;
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -9,6 +11,7 @@ import androidx.appcompat.app.AlertDialog;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableNativeMap;
 import com.imagepicker.ImagePickerModule;
+import com.imagepicker.utils.ReadableMapUtils;
 
 import java.lang.ref.WeakReference;
 
@@ -79,5 +82,17 @@ public class PermissionUtils
     public interface OnExplainingPermissionCallback {
         void onCancel(WeakReference<ImagePickerModule> moduleInstance, DialogInterface dialogInterface);
         void onReTry(WeakReference<ImagePickerModule> moduleInstance, DialogInterface dialogInterface);
+    }
+
+    public static boolean needsExternalStoragePermission(@NonNull final ReadableMap options) {
+        // SDK < 21 always require WRITE_EXTERNAL_STORAGE
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) return true;
+
+        // SDK >= 21 only requires WRITE_EXTERNAL_STORAGE when writing to public directory
+        // which is the default, except when storageOptions.privateDirectory is set to true
+        if (!ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions")) return true;
+        final ReadableMap storageOptions = options.getMap("storageOptions");
+        if (storageOptions == null || !storageOptions.hasKey("privateDirectory")) return true;
+        return !storageOptions.getBoolean("privateDirectory");
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "2.3.1",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
   "react-native": "src/index.ts",
-  "types": "lib/typescript/index.d.ts",
-  "main": "lib/commonjs/index.js",
-  "module": "lib/module/index.js",
+  "main": "src/index.ts",
   "files": [
     "/android",
     "!/android/build",
@@ -42,8 +40,7 @@
     "validate:typescript": "tsc --project ./ --noEmit",
     "test:jest": "jest \"/src/\"",
     "ci:publish": "yarn semantic-release",
-    "semantic-release": "semantic-release",
-    "prepare": "bob build"
+    "semantic-release": "semantic-release"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

This brings in the patch from https://github.com/react-native-community/react-native-image-picker/pull/1343, to address a security issue due to the app asking for permission to write to the sd card when the app does not actually write to the SD Card.

## Test Plan (required)

See https://github.com/react-native-community/react-native-image-picker/pull/1343.
