### PR TITLE
Removing deprecated gradle property

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -7,4 +7,4 @@ ReactNativeImagePicker_minSdkVersion=16
 
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableUnitTestBinaryResources=true
+


### PR DESCRIPTION
The option 'android.enableUnitTestBinaryResources' is deprecated.
It has been removed from the newer version of the Android Gradle plugin used by Android 11.

